### PR TITLE
Replace st.markdown with st.write in Streamlit Frontend

### DIFF
--- a/podcast_frontend.py
+++ b/podcast_frontend.py
@@ -41,14 +41,13 @@ def main():
     if process_button:
         podcast_info = {}
 
-        st.markdown('<div id="spinner-anchor"></div>', unsafe_allow_html=True)
-        st.markdown(
+        st.write('<div id="spinner-anchor"></div>')
+        st.write(
             """
             <script>
             document.querySelector("#spinner-anchor").scrollIntoView({ behavior: 'smooth' });
             </script>
-            """,
-            unsafe_allow_html=True,
+            """
         )
 
         # Process the new podcast feed


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR replaces the usage of `st.markdown` with `st.write` in the Streamlit frontend. This change is made to improve the code readability and maintainability.

___
## PR Main Files Walkthrough:
`podcast_frontend.py`: The `st.markdown` function calls used to display a spinner and scroll into view script have been replaced with `st.write` function calls. The change is aimed at improving the code readability and maintainability.
