### PR TITLE
Fix: Use Correct Streamlit Write Strategy in Podcast Frontend

### DIFF
--- a/podcast_frontend.py
+++ b/podcast_frontend.py
@@ -41,13 +41,14 @@ def main():
     if process_button:
         podcast_info = {}
 
-        st.write('<div id="spinner-anchor"></div>')
-        st.write(
+        st.markdown('<div id="spinner-anchor"></div>', unsafe_allow_html=True)
+        st.markdown(
             """
             <script>
             document.querySelector("#spinner-anchor").scrollIntoView({ behavior: 'smooth' });
             </script>
-            """
+            """,
+            unsafe_allow_html=True
         )
 
         # Process the new podcast feed


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR fixes the way Streamlit's write strategy is used in the podcast frontend. It replaces the usage of `st.write` with `st.markdown` and enables the `unsafe_allow_html` parameter to allow the inclusion of HTML content.

___
## PR Main Files Walkthrough:
`podcast_frontend.py`: Replaced `st.write` with `st.markdown` and enabled `unsafe_allow_html` parameter to allow HTML content. This change was applied when processing the podcast feed and scrolling into view the spinner anchor.
